### PR TITLE
Added 'native' task

### DIFF
--- a/src/main/scala/RobovmPlugin.scala
+++ b/src/main/scala/RobovmPlugin.scala
@@ -26,5 +26,7 @@ object RobovmPlugin extends Plugin {
   val ipadSim = TaskKey[Unit]("ipad-sim", "Start package on ipad simulator")
   val ipa = TaskKey[Unit]("ipa", "Create an ipa file for the app store")
 
+  val native = TaskKey[Unit]("native", "Run as native console application")
+
   val RobovmProject = RobovmProjects.Standard
 }


### PR DESCRIPTION
Added a 'native' task in order to run a native console application. I added parameters 'os' and 'targetType' to method 'launchTask', and pass in the previously defined values as parameters from 'iphoneSimTask', 'ipadSimTask' and 'ipaTask'. I also explicitly defined a temporary directory ("target/native"), so that the user can locate the generated binaries.
I haven't tested the i-device specific functionality after the change, but launching a native console application now works on my system.
