### PR TITLE
Fix scopes not being retrieved correctly

### DIFF
--- a/src/main/scala/sbtrobovm/RobovmPlugin.scala
+++ b/src/main/scala/sbtrobovm/RobovmPlugin.scala
@@ -1,6 +1,6 @@
 package sbtrobovm
 
-import org.robovm.compiler.config.Config
+import org.robovm.compiler.config.{OS, Arch, Config}
 import sbt._
 import sbtrobovm.interfacebuilder.{RobovmInterfaceBuilder, IBIntegratorProxy}
 
@@ -19,7 +19,7 @@ object RobovmPlugin extends AutoPlugin with RobovmUtils {
   val robovmConfiguration = taskKey[Either[File,Elem]]("robovm.xml configuration")
   val robovmDebugPort = settingKey[Int]("Port on which debugger will listen (when enabled)")
   val robovmDebug = settingKey[Boolean]("Whether to enable robovm debugger (Needs commercial license, run robovmLicense task to enter one)")
-  val robovmTarget64bit = settingKey[Boolean]("Whether to build 64bit executables")
+  val robovmTargetArch = settingKey[Array[Arch]]("Architecture(s) targeted when building with RoboVM (scoped to each building task)")
   //Internal
   /** It is a task, because `streams` is a task. */
   val robovmCompilerLogger = taskKey[org.robovm.compiler.log.Logger]("Logger supplied to the RoboVM compiler")
@@ -40,10 +40,13 @@ object RobovmPlugin extends AutoPlugin with RobovmUtils {
   val robovmProvisioningProfile = settingKey[Option[String]]("Specify provisioning profile to use when signing iOS code.")
   val robovmSigningIdentity = settingKey[Option[String]]("Specify signing identity to use when signing iOS code.")
   val robovmPreferredDevices = settingKey[Seq[String]]("List of iOS device ID's from which device will be chosen if multiple are detected.")
+  val robovmTarget64bit = settingKey[Boolean]("Whether to build 64bit executables, only affects default values of robovmTargetArch in iOS projects")
 
   // Native Only
   val native = taskKey[Unit]("Run as native console application")
   val nativeBuild = taskKey[Unit]("Compile and archive for distribution as native application")
+
+  val robovmTargetOS = settingKey[Option[OS]]("Operating System targeted when building with RoboVM (scoped to each building task)")
 
   /* Tools */
   val robovmLicense = taskKey[Unit]("Launch UI for entering a RoboVM license key.")
@@ -61,7 +64,7 @@ object RobovmPlugin extends AutoPlugin with RobovmUtils {
     val robovmConfiguration = RobovmPlugin.robovmConfiguration
     val robovmDebugPort = RobovmPlugin.robovmDebugPort
     val robovmDebug = RobovmPlugin.robovmDebug
-    val robovmTarget64bit = RobovmPlugin.robovmTarget64bit
+    val robovmTargetArch = RobovmPlugin.robovmTargetArch
 
     /* Specific settings and tasks */
     // iOS Only
@@ -75,11 +78,14 @@ object RobovmPlugin extends AutoPlugin with RobovmUtils {
     val robovmProvisioningProfile = RobovmPlugin.robovmProvisioningProfile
     val robovmSigningIdentity = RobovmPlugin.robovmSigningIdentity
     val robovmPreferredDevices = RobovmPlugin.robovmPreferredDevices
+    val robovmTarget64bit = RobovmPlugin.robovmTarget64bit
 
     val robovmIBScope = RobovmPlugin.robovmIBScope
     // Native Only
     val native = RobovmPlugin.native
     val nativeBuild = RobovmPlugin.nativeBuild
+
+    val robovmTargetOS = RobovmPlugin.robovmTargetOS
 
     /* Tools */
     val robovmLicense = RobovmPlugin.robovmLicense

--- a/src/main/scala/sbtrobovm/RobovmProjects.scala
+++ b/src/main/scala/sbtrobovm/RobovmProjects.scala
@@ -15,13 +15,11 @@ import sbt._
 import sbtrobovm.RobovmPlugin._
 import sbtrobovm.interfacebuilder.RobovmInterfaceBuilder
 
-import scala.util.{Failure, Success, Try}
-
 object RobovmProjects {
 
   type TargetType = String
 
-  def configTask(arch: Array[Arch], os: OS, targetType: TargetType, skipInstall: Boolean, scope:Scope) = Def.task[Config.Builder] {
+  def configTask(arch: Def.Initialize[Array[Arch]], os: Def.Initialize[Option[OS]], targetType: TargetType, skipInstall: Boolean, scope:Scope) = Def.task[Config.Builder] {
     val log = (streams in scope).value.log
 
     val builder = new Config.Builder()
@@ -58,8 +56,14 @@ object RobovmProjects {
     //To make sure that options were not overrided, that would not work.
     builder.skipInstall(skipInstall)
     builder.targetType(targetType)
-    builder.os(os)
-    builder.archs(arch:_*)
+    os.value match {
+      case Some(selectedOS) =>
+        builder.os(selectedOS)
+        log.debug("Setting OS to "+selectedOS)
+      case None =>
+        log.debug("OS not specified")
+    }
+    builder.archs(arch.value:_*)
 
     val t = target.value
     builder.installDir(t / "robovm")
@@ -249,7 +253,7 @@ object RobovmProjects {
   def buildSimulatorTask(scope:Scope) = Def.task[(Config, AppCompiler)]{
     buildTask(
       configIOSTask(
-        configTask(Array(if((robovmTarget64bit in scope).value)Arch.x86_64 else Arch.x86), OS.ios, IOSTarget.TYPE, skipInstall = true, scope),
+        configTask(robovmTargetArch in simulator, robovmTargetOS in scope, IOSTarget.TYPE, skipInstall = true, scope),
         scope
       )
     ).value
@@ -266,7 +270,7 @@ object RobovmProjects {
 
   private def deviceTask(scope:Scope) = Def.task[Unit]{
     val log = streams.value.log
-    val (config, compiler) = buildTask(configIOSTask(configTask(Array(if((robovmTarget64bit in device).value)Arch.arm64 else Arch.thumbv7), OS.ios, IOSTarget.TYPE, skipInstall = true, scope), device.scope)).value
+    val (config, compiler) = buildTask(configIOSTask(configTask(robovmTargetArch in device, robovmTargetOS in scope, IOSTarget.TYPE, skipInstall = true, scope), device.scope)).value
 
     val launchParameters = config.getTarget.createLaunchParameters()
 
@@ -326,8 +330,11 @@ object RobovmProjects {
     robovmSigningIdentity := None,
     robovmPreferredDevices := Nil,
     lastUsedDeviceFile := target.value / "LastUsediOSDevice.txt",
+
     device := deviceTask(device.scope).value,
     device in Debug := deviceTask(device.scope.in(Debug)).value,
+    robovmTargetArch in device := Array(if((robovmTarget64bit in device).value) Arch.arm64 else Arch.thumbv7),
+
     //TODO Allow specifying SDK version and device version in simulator tasks?
     iphoneSim := simulatorTask(iphoneSim.scope, DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPhone)).value,
     iphoneSim in Debug := simulatorTask(iphoneSim.scope.in(Debug), DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPhone)).value,
@@ -335,10 +342,16 @@ object RobovmProjects {
     ipadSim in Debug := simulatorTask(ipadSim.scope.in(Debug), DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPad)).value,
     simulator := simulatorTask(simulator.scope, null).value,
     simulator in Debug := simulatorTask(simulator.scope.in(Debug), null).value,
+    robovmTargetArch in simulator := Array(if((robovmTarget64bit in simulator).value) Arch.x86_64 else Arch.x86),
+
+    robovmTarget64bit := false,
+
     ipa := {
-      val (_, compiler) = buildTask(configIOSTask(configTask(Array(Arch.thumbv7, Arch.arm64), OS.ios, IOSTarget.TYPE, skipInstall = false, ipa.scope), ipa.scope)).value
+      val (_, compiler) = buildTask(configIOSTask(configTask(robovmTargetArch in ipa, robovmTargetOS in ipa, IOSTarget.TYPE, skipInstall = false, ipa.scope), ipa.scope)).value
       compiler.archive()
     },
+   robovmTargetOS := Some(OS.ios),
+   robovmTargetArch in ipa := Array(Arch.thumbv7, Arch.arm64),
     simulatorDevices := {
       val devices = DeviceType.getSimpleDeviceTypeIds
       for (simpleDevice <- scala.collection.convert.wrapAsScala.iterableAsScalaIterable(devices)) {
@@ -351,33 +364,42 @@ object RobovmProjects {
 
   //region Native
 
-  val robovmTargetArchitecture = settingKey[Array[Arch]]("Architecture(s) targeted by NativeProject")
-
   private def nativeTask(scope:Scope, buildOnly:Boolean) = Def.task[Unit]{
     val log = streams.value.log
 
-    Try(OS.getDefaultOS) match {
-      case Success(os) =>
-        val (config, compiler) = buildTask(configTask(robovmTargetArchitecture.value, os, ConsoleTarget.TYPE, skipInstall = true, scope)).value
+    val (config, compiler) = buildTask(configTask(robovmTargetArch in scope, robovmTargetOS in scope, ConsoleTarget.TYPE, skipInstall = true, scope)).value
 
-        if(buildOnly){
-          compiler.install()
-          log.debug("nativeBuild task finished")
-        }else{
-          val launchParameters = config.getTarget.createLaunchParameters()
-          val code = compiler.launch(launchParameters)
-          log.debug("native task finished (exit code "+code+")")
-        }
-      case Failure(exception) =>
-        log.error("Native compiling is not supported on this platform")
-        log.debug("Caused by: "+exception)
+    if(config.getOs == null){
+      log.error("Native compiling is not supported on this platform")
+    }else if(buildOnly){
+      compiler.install()
+      log.debug("nativeBuild task finished")
+    }else{
+      val launchParameters = config.getTarget.createLaunchParameters()
+      val code = compiler.launch(launchParameters)
+      log.debug("native task finished (exit code "+code+")")
     }
   }
 
 
   lazy val nativeProjectSettings = Seq(
-    robovmTargetArchitecture := {
-      Try(Arch.getDefaultArch).map(Array(_)).getOrElse(Array.empty[Arch])
+    robovmTargetArch := {
+      try {
+        Array(Arch.getDefaultArch)
+      }catch{
+        case _:Throwable =>
+          //getDefaultArch May throw java.lang.UnsatisfiedLinkError, which is not caught by scala.util.Try
+          Array.empty[Arch]
+      }
+    },
+    robovmTargetOS := {
+      try {
+        Some(OS.getDefaultOS)
+      }catch{
+        case _:Throwable =>
+          //getDefaultOS May throw java.lang.UnsatisfiedLinkError, which is not caught by scala.util.Try
+          None
+      }
     },
     native := nativeTask(native.scope, buildOnly = false).value,
     native in Debug := nativeTask(native.scope.in(Debug), buildOnly = false).value,

--- a/src/main/scala/sbtrobovm/RobovmProjects.scala
+++ b/src/main/scala/sbtrobovm/RobovmProjects.scala
@@ -21,6 +21,7 @@ object RobovmProjects {
 
   def configTask(arch: Def.Initialize[Array[Arch]], os: Def.Initialize[Option[OS]], targetType: TargetType, skipInstall: Boolean, scope:Scope) = Def.task[Config.Builder] {
     val log = (streams in scope).value.log
+    log.debug("configTask - Configuring for scope: "+scope)
 
     val builder = new Config.Builder()
     builder.logger(robovmCompilerLogger.value)
@@ -270,7 +271,7 @@ object RobovmProjects {
 
   private def deviceTask(scope:Scope) = Def.task[Unit]{
     val log = streams.value.log
-    val (config, compiler) = buildTask(configIOSTask(configTask(robovmTargetArch in device, robovmTargetOS in scope, IOSTarget.TYPE, skipInstall = true, scope), device.scope)).value
+    val (config, compiler) = buildTask(configIOSTask(configTask(robovmTargetArch in device, robovmTargetOS in scope, IOSTarget.TYPE, skipInstall = true, scope), ThisScope.in(device.key))).value
 
     val launchParameters = config.getTarget.createLaunchParameters()
 
@@ -331,23 +332,23 @@ object RobovmProjects {
     robovmPreferredDevices := Nil,
     lastUsedDeviceFile := target.value / "LastUsediOSDevice.txt",
 
-    device := deviceTask(device.scope).value,
-    device in Debug := deviceTask(device.scope.in(Debug)).value,
+    device := deviceTask(ThisScope.in(device.key)).value,
+    device in Debug := deviceTask(ThisScope.in(device.key).in(Debug)).value,
     robovmTargetArch in device := Array(if((robovmTarget64bit in device).value) Arch.arm64 else Arch.thumbv7),
 
     //TODO Allow specifying SDK version and device version in simulator tasks?
-    iphoneSim := simulatorTask(iphoneSim.scope, DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPhone)).value,
-    iphoneSim in Debug := simulatorTask(iphoneSim.scope.in(Debug), DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPhone)).value,
-    ipadSim := simulatorTask(ipadSim.scope, DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPad)).value,
-    ipadSim in Debug := simulatorTask(ipadSim.scope.in(Debug), DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPad)).value,
-    simulator := simulatorTask(simulator.scope, null).value,
-    simulator in Debug := simulatorTask(simulator.scope.in(Debug), null).value,
+    iphoneSim := simulatorTask(ThisScope.in(iphoneSim.key), DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPhone)).value,
+    iphoneSim in Debug := simulatorTask(ThisScope.in(iphoneSim.key).in(Debug), DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPhone)).value,
+    ipadSim := simulatorTask(ThisScope.in(ipadSim.key), DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPad)).value,
+    ipadSim in Debug := simulatorTask(ThisScope.in(ipadSim.key).in(Debug), DeviceType.getBestDeviceType(DeviceType.DeviceFamily.iPad)).value,
+    simulator := simulatorTask(ThisScope.in(simulator.key), null).value,
+    simulator in Debug := simulatorTask(ThisScope.in(simulator.key).in(Debug), null).value,
     robovmTargetArch in simulator := Array(if((robovmTarget64bit in simulator).value) Arch.x86_64 else Arch.x86),
 
     robovmTarget64bit := false,
 
     ipa := {
-      val (_, compiler) = buildTask(configIOSTask(configTask(robovmTargetArch in ipa, robovmTargetOS in ipa, IOSTarget.TYPE, skipInstall = false, ipa.scope), ipa.scope)).value
+      val (_, compiler) = buildTask(configIOSTask(configTask(robovmTargetArch in ipa, robovmTargetOS in ipa, IOSTarget.TYPE, skipInstall = false, ThisScope.in(ipa.key)), ThisScope.in(ipa.key))).value
       compiler.archive()
     },
    robovmTargetOS := Some(OS.ios),
@@ -401,10 +402,10 @@ object RobovmProjects {
           None
       }
     },
-    native := nativeTask(native.scope, buildOnly = false).value,
-    native in Debug := nativeTask(native.scope.in(Debug), buildOnly = false).value,
-    nativeBuild := nativeTask(native.scope, buildOnly = true).value,
-    nativeBuild in Debug := nativeTask(native.scope.in(Debug), buildOnly = true).value
+    native := nativeTask(ThisScope.in(native.key), buildOnly = false).value,
+    native in Debug := nativeTask(ThisScope.in(native.key).in(Debug), buildOnly = false).value,
+    nativeBuild := nativeTask(ThisScope.in(native.key), buildOnly = true).value,
+    nativeBuild in Debug := nativeTask(ThisScope.in(native.key).in(Debug), buildOnly = true).value
   )
     
   //endregion

--- a/src/main/scala/sbtrobovm/interfacebuilder/RobovmInterfaceBuilder.scala
+++ b/src/main/scala/sbtrobovm/interfacebuilder/RobovmInterfaceBuilder.scala
@@ -3,13 +3,12 @@ package sbtrobovm.interfacebuilder
 import java.io.File
 import java.util
 
-import org.robovm.compiler.config.OS
 import org.robovm.compiler.target.ios.IOSTarget
 import sbt.Keys._
 import sbt._
 import sbt.complete.DefaultParsers._
 import sbtrobovm.RobovmPlugin._
-import sbtrobovm.RobovmProjects
+import sbtrobovm.{RobovmPlugin, RobovmProjects}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -66,7 +65,7 @@ object RobovmInterfaceBuilder {
       val integratorProxyEither = integratorProxies(project)
       integratorProxyEither match {
         case Right(ibProxy) =>
-          val configuration = RobovmProjects.configTask(RobovmProjects.ipaArchitectureSetting, OS.ios, IOSTarget.TYPE, skipInstall = true, robovmIBIntegrator.scope).value.build()
+          val configuration = RobovmProjects.configTask(RobovmPlugin.robovmTargetArch in ipa, robovmTargetOS in ipa, IOSTarget.TYPE, skipInstall = true, robovmIBIntegrator.scope).value.build()
 
           //Not sure what classpath and source folders should be. robovm-idea seems to set it to compile out of the project
           val classpath = new util.ArrayList[File]()

--- a/src/main/scala/sbtrobovm/interfacebuilder/RobovmInterfaceBuilder.scala
+++ b/src/main/scala/sbtrobovm/interfacebuilder/RobovmInterfaceBuilder.scala
@@ -65,7 +65,7 @@ object RobovmInterfaceBuilder {
       val integratorProxyEither = integratorProxies(project)
       integratorProxyEither match {
         case Right(ibProxy) =>
-          val configuration = RobovmProjects.configTask(RobovmPlugin.robovmTargetArch in ipa, robovmTargetOS in ipa, IOSTarget.TYPE, skipInstall = true, robovmIBIntegrator.scope).value.build()
+          val configuration = RobovmProjects.configTask(RobovmPlugin.robovmTargetArch in ipa, robovmTargetOS in ipa, IOSTarget.TYPE, skipInstall = true, ThisScope.in(robovmIBIntegrator.key)).value.build()
 
           //Not sure what classpath and source folders should be. robovm-idea seems to set it to compile out of the project
           val classpath = new util.ArrayList[File]()


### PR DESCRIPTION
_I swear it has worked before, but apparently it didn't. What?_

This PR builds on top of #54.

This bug would cause things like `robovmProvisioningProfile in ipa := ...distribution profile...' to not work, since `ipa` task would still retrieve unscoped `robovmProvisioningProfile`, most likely set to development profile.